### PR TITLE
Convert UUIDs into actual UUIDs instead of storing as String.

### DIFF
--- a/src/main/java/soot/itemmod/ModifierMundane.java
+++ b/src/main/java/soot/itemmod/ModifierMundane.java
@@ -37,7 +37,7 @@ import java.util.regex.Pattern;
 
 public class ModifierMundane extends ModifierBase {
     static final UUID ATTACK_DAMAGE_MODIFIER = UUID.fromString("CB3F55D3-645C-4F38-A497-9C13A33DB5CF");
-    static final String ATTACK_BONUS_UUID = "051b0eb9-ecbd-402e-83d6-e99455da641c";
+    static final UUID ATTACK_BONUS_UUID = UUID.fromString("051b0eb9-ecbd-402e-83d6-e99455da641c");
     public static final String CODE_STAT = MiscUtil.generateFormatMatchCode(114);
     public static final String CODE_NOSTAT = MiscUtil.generateFormatMatchCode(115);
     public static final String GLOW_FORMAT = "!=!";
@@ -61,23 +61,22 @@ public class ModifierMundane extends ModifierBase {
             return;
         ItemStack stack = entity.getHeldItemMainhand();
         IAttributeInstance instance = entity.getEntityAttribute(SharedMonsterAttributes.ATTACK_DAMAGE);
-        UUID uuid = UUID.fromString(ATTACK_BONUS_UUID);
         boolean isMundane = ItemModUtil.hasHeat(stack) && ItemModUtil.hasModifier(stack, Registry.MUNDANE);
 
         if(instance != null) { //This can happen.
             if (isMundane) {
                 double mundaneBonus = getMundaneBonus(stack);
-                AttributeModifier modifier = instance.getModifier(uuid);
+                AttributeModifier modifier = instance.getModifier(ATTACK_BONUS_UUID);
                 if (modifier != null) {
                     double currentBonus = ATTRIBUTE_CACHE.getOrDefault(entity, modifier.getAmount());
                     if (currentBonus != mundaneBonus)
                         instance.removeModifier(modifier);
                 } else {
-                    instance.applyModifier(new AttributeModifier(uuid, "mundane_bonus", mundaneBonus, 0));
+                    instance.applyModifier(new AttributeModifier(ATTACK_BONUS_UUID, "mundane_bonus", mundaneBonus, 0));
                 }
                 ATTRIBUTE_CACHE.put(entity, mundaneBonus);
             } else {
-                AttributeModifier modifier = instance.getModifier(uuid);
+                AttributeModifier modifier = instance.getModifier(ATTACK_BONUS_UUID);
                 if (modifier != null)
                     instance.removeModifier(modifier);
                 ATTRIBUTE_CACHE.remove(entity);

--- a/src/main/java/soot/potion/PotionLifedrinker.java
+++ b/src/main/java/soot/potion/PotionLifedrinker.java
@@ -14,7 +14,7 @@ import java.awt.*;
 import java.util.UUID;
 
 public class PotionLifedrinker extends PotionBase {
-    static final String HEALTH_BOOST_UUID = "ce99d4f2-ae8f-499c-a4e6-66c88dcf0938";
+    static final UUID HEALTH_BOOST_UUID = UUID.fromString("ce99d4f2-ae8f-499c-a4e6-66c88dcf0938");
 
     public PotionLifedrinker() {
         super(false, new Color(90,20,20).getRGB());
@@ -37,21 +37,20 @@ public class PotionLifedrinker extends PotionBase {
         if(killer != null && !killer.world.isRemote && killer.isPotionActive(this))
         {
             IAttributeInstance instance = killer.getEntityAttribute(SharedMonsterAttributes.MAX_HEALTH);
-            UUID uuid = UUID.fromString(HEALTH_BOOST_UUID);
-            AttributeModifier modifier = instance.getModifier(uuid);
+            AttributeModifier modifier = instance.getModifier(HEALTH_BOOST_UUID);
             int newHealth = 2;
             if(modifier != null && modifier.getOperation() == 0) {
                 newHealth += modifier.getAmount();
                 instance.removeModifier(modifier);
             }
             newHealth = Math.min(newHealth,20); //Lets not go overboard
-            instance.applyModifier(new AttributeModifier(uuid,getName(),newHealth,0));
+            instance.applyModifier(new AttributeModifier(HEALTH_BOOST_UUID, getName(),newHealth,0));
         }
     }
 
     @Override
     public void removeAttributesModifiersFromEntity(EntityLivingBase entityLivingBaseIn, AbstractAttributeMap attributeMapIn, int amplifier) {
         IAttributeInstance instance = attributeMapIn.getAttributeInstance(SharedMonsterAttributes.MAX_HEALTH);
-        instance.removeModifier(UUID.fromString(HEALTH_BOOST_UUID));
+        instance.removeModifier(HEALTH_BOOST_UUID);
     }
 }


### PR DESCRIPTION
UUID.fromString is not an inexpensive operation. It's not hugely bad,
but it was one of the things that got highlighted while trying to track
down the source of lag on my multiplayer server, especially where it was
happening with every tick (Modifier Mundane).

I've tested the code to the extend that it compiles and launches and I
haven't crashed after jetting around a test world for a few minutes.

I don't believe this causes any other issues.